### PR TITLE
v2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 1.4
+  - 1.7
   - nightly
 matrix:
   allow_failures:

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,105 +1,78 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Base64]]
-uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+julia_version = "1.7.2"
+manifest_format = "2.0"
 
-[[ColorTypes]]
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "4bffea7ed1a9f0f3d1a131bbcd4b925548d75288"
+git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.9"
+version = "0.11.0"
 
-[[Colors]]
-deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Reexport"]
-git-tree-sha1 = "008d6bc68dea6beb6303fdc37188cb557391ebf2"
+[[deps.Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.4"
+version = "0.12.8"
 
-[[Dates]]
-deps = ["Printf"]
-uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 
-[[FixedPointNumbers]]
+[[deps.FixedPointNumbers]]
 deps = ["Statistics"]
 git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
-[[GeometricalPredicates]]
-git-tree-sha1 = "04776c0dc233eafa617b1a52ca58db2338b08836"
+[[deps.GeometricalPredicates]]
+git-tree-sha1 = "527d55e28ff359029d8f72d77c0bdcaf28793079"
 uuid = "fd0ad045-b25c-564e-8f9c-8ef5c5f21267"
-version = "0.4.0"
+version = "0.4.1"
 
-[[InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[LibGit2]]
-deps = ["Printf"]
-uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[Logging]]
-uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
-[[Markdown]]
-deps = ["Base64"]
-uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[[Printf]]
-deps = ["Unicode"]
-uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
-[[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-
-[[Random]]
-deps = ["Serialization"]
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[Reexport]]
-deps = ["Pkg"]
-git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "0.2.0"
+version = "1.2.2"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[UUIDs]]
-deps = ["Random", "SHA"]
-uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-
-[[Unicode]]
-uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[VoronoiDelaunay]]
+[[deps.VoronoiDelaunay]]
 deps = ["Colors", "GeometricalPredicates", "Random"]
-git-tree-sha1 = "da5560a4c7c767476e85e2dbf4d8c8ca112e542b"
+git-tree-sha1 = "ed19f55808fb99951d36e8616a95fc9d94045466"
 uuid = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
-version = "0.4.0"
+version = "0.4.1"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 Important notices about MAJOR and MINOR version releases.
 
+- `v1.5.0`: Minimum Julia version now `v1.7`. Removes custom implementation of fast `delaunayedges`.
+
 - `v1.4.0`: Provides a new function for preparing data for plotting, `getplotdata`.
 A fix for `rectangulardomain` is also included that, as a side effect, shifts the nodes produced by the old `rectangulardomain` by a half spacing.
 This may cause slightly different root and pole locations from `grpf`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RootsAndPoles"
 uuid = "a0859a10-ccb4-11e8-145d-674b3750773a"
 authors = ["Forrest Gasdia <EP-Guy@users.noreply.github.com>"]
-version = "1.5.0"
+version = "2.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,15 @@
 name = "RootsAndPoles"
 uuid = "a0859a10-ccb4-11e8-145d-674b3750773a"
 authors = ["Forrest Gasdia <EP-Guy@users.noreply.github.com>"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 VoronoiDelaunay = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
 
 [compat]
-VoronoiDelaunay = "0.4"
-julia = "1.4"
+VoronoiDelaunay = "0.4.1"
+julia = "1.7"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-    - julia_version: 1.4
+    - julia_version: 1.7
     - julia_version: latest
 
 platform:

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,87 +1,86 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Base64]]
-uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+manifest_format = "2.0"
 
-[[BenchmarkTools]]
-deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
-git-tree-sha1 = "9e62e66db34540a0c919d72172cc2f642ac71260"
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "4c10eee4af024676200bc7752e536f858c6b8f93"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "0.5.0"
+version = "1.3.1"
 
-[[Dates]]
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
-[[InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[JSON]]
+[[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.0"
+version = "0.21.3"
 
-[[Libdl]]
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[Logging]]
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[Markdown]]
-deps = ["Base64"]
-uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[Mmap]]
+[[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[Parsers]]
-deps = ["Dates", "Test"]
-git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"
-uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.10"
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
-[[Printf]]
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "13468f237353112a01b2d6b32f3d0f80219944aa"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.2.2"
+
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[Random]]
-deps = ["Serialization"]
+[[deps.Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"

--- a/src/RootsAndPoles.jl
+++ b/src/RootsAndPoles.jl
@@ -41,7 +41,7 @@ const MINCOORD = nextfloat(min_coord, 10)
 """
     GRPFParams
 
-Mutable struct for holding values used by `RootsAndPoles` to stop iterating or split
+Struct for holding values used by `RootsAndPoles` to stop iterating or split
 Delaunay triangles.
 
 Default values are provided by `GRPFParams()`.
@@ -62,7 +62,7 @@ Default values are provided by `GRPFParams()`.
 - `multithreading::Bool = false`: use `Threads.@threads` to run the user-provided function
     `fcn` across the `DelaunayTriangulation`.
 """
-mutable struct GRPFParams
+struct GRPFParams
     maxiterations::Int
     maxnodes::Int
     skinnytriangle::Int

--- a/src/RootsAndPoles.jl
+++ b/src/RootsAndPoles.jl
@@ -152,9 +152,8 @@ Convert complex function value `val` to quadrant number.
 |    3     | π ≤ arg f < 3π/2  |
 |    4     | 3π/2 ≤ arg f < 2π |
 """
-@inline function quadrant(val)::Int8
+@inline function quadrant(val)
     # This function correponds to `vinq.m`
-
     rv, iv = reim(val)
     if (rv > 0) & (iv >= 0)
         return 1
@@ -173,23 +172,15 @@ end
 
 Evaluate function `f` for [`quadrant`](@ref) at `nodes` and fill `quadrants` in-place.
 
-Each element of `quadrants` corresponds to the index of `IndexablePoint2D` in `nodes`.
+Each element of `quadrants` corresponds to the `index` of `IndexablePoint2D` in `nodes`.
 """
-function assignquadrants!(
-    quadrants::Vector{<:Integer},
-    nodes::Vector{IndexablePoint2D},
-    f::ScaledFunction{F,G},
-    multithreading=false
-    ) where {F,G}
-
+function assignquadrants!(quadrants, nodes, f::ScaledFunction{F,G}, multithreading=false) where {F,G}
     if multithreading
-        @threads for ii in eachindex(nodes)
-            p = @inbounds nodes[ii]
+        @threads for p in nodes
             quadrants[getindex(p)] = quadrant(f(p))
         end
     else
-        for ii in eachindex(nodes)
-            p = @inbounds nodes[ii]
+        for p in nodes
             quadrants[getindex(p)] = quadrant(f(p))
         end
     end
@@ -603,7 +594,7 @@ Identify roots and poles of function based on regions and quadrants.
 """
 function rootsandpoles(
     regions::Vector{Vector{IndexablePoint2D}},
-    quadrants::Vector{Int8},
+    quadrants::Vector{Int},
     g2f::Geometry2Function{T}
     ) where T
 
@@ -661,7 +652,7 @@ function tesselate!(
     g2f = f.g2f
 
     E = Vector{DelaunayEdge{IndexablePoint2D}}()
-    quadrants = Vector{Int8}()
+    quadrants = Vector{Int}()
     edge_idxs = Vector{Int}()
     zone1triangles = Vector{DelaunayTriangle{IndexablePoint2D}}()
 
@@ -671,7 +662,7 @@ function tesselate!(
 
         # Determine which quadrant function value belongs at each node
         numnewnodes = length(newnodes)
-        append!(quadrants, Vector{Int8}(undef, numnewnodes))
+        append!(quadrants, Vector{Int}(undef, numnewnodes))
         assignquadrants!(quadrants, newnodes, f, params.multithreading)
 
         # Add new nodes to `tess`

--- a/src/RootsAndPoles.jl
+++ b/src/RootsAndPoles.jl
@@ -269,7 +269,7 @@ function candidateedges!(
 
     phasediffs = Vector{Int8}()
 
-    for edge in delaunayedges_fast(tess)
+    for edge in delaunayedges(tess)
         nodea, nodeb = geta(edge), getb(edge)
         idxa, idxb = getindex(nodea), getindex(nodeb)
 

--- a/src/VoronoiDelaunayExtensions.jl
+++ b/src/VoronoiDelaunayExtensions.jl
@@ -2,34 +2,34 @@
     IndexablePoint2D <: AbstractPoint2D
 
 A special 2D point type, compatible with `VoronoiDelaunay`, that carries an
-identifying `_index` field.
+identifying `index` field.
 
-By default, `_index` is -1.
+By default, `index` is -1.
 
 See also: `setindex!`, `getindex`
 """
 mutable struct IndexablePoint2D <: AbstractPoint2D
-    _x::Float64
-    _y::Float64
-    _index::Int
+    x::Float64
+    y::Float64
+    index::Int
 end
-IndexablePoint2D(x::Float64, y::Float64) = IndexablePoint2D(x, y, -1)
-getx(p::IndexablePoint2D) = p._x
-gety(p::IndexablePoint2D) = p._y
+IndexablePoint2D(x, y) = IndexablePoint2D(x, y, -1)
+getx(p::IndexablePoint2D) = p.x
+gety(p::IndexablePoint2D) = p.y
 Base.:+(p1::IndexablePoint2D, p2::IndexablePoint2D) = IndexablePoint2D(getx(p1)+getx(p2), gety(p1)+gety(p2), -1)
-Base.:/(p1::IndexablePoint2D, n::Real) = IndexablePoint2D(getx(p1)/n, gety(p1)/n, -1)
+Base.:/(p::IndexablePoint2D, n) = IndexablePoint2D(getx(p)/n, gety(p)/n, -1)
 
 """
     getindex(p::IndexablePoint2D)
 
-Return `_index` field of `p`.
+Return `index` field of `p`.
 """
-Base.getindex(p::IndexablePoint2D) = p._index
+Base.getindex(p::IndexablePoint2D) = p.index
 
 """
     setindex!(p::IndexablePoint2D)
 
-Set the `_index` field of `p`.
+Set the `index` field of `p`.
 
 # Example
 
@@ -45,7 +45,7 @@ julia> getindex(p)
 90
 ```
 """
-Base.setindex!(p::IndexablePoint2D, v::Int) = setfield!(p, :_index, v)
+Base.setindex!(p::IndexablePoint2D, v::Int) = setfield!(p, :index, v)
 
 """
     same(e1::DelaunayEdge{IndexablePoint2D}, e2::DelaunayEdge{IndexablePoint2D})
@@ -60,8 +60,8 @@ distinguish them, use `===`.
     e1 === e2 && return true
 
     # if they're reversed
-    e1a, e1b = geta(e1)._index, getb(e1)._index
-    e2a, e2b = geta(e2)._index, getb(e2)._index
+    e1a, e1b = geta(e1).index, getb(e1).index
+    e2a, e2b = geta(e2).index, getb(e2).index
     (e1a == e2b) && (e1b == e2a) && return true
 
     return false

--- a/src/VoronoiDelaunayExtensions.jl
+++ b/src/VoronoiDelaunayExtensions.jl
@@ -96,27 +96,3 @@ function sameunique!(v::AbstractVector{DelaunayEdge{IndexablePoint2D}})
 
     deleteat!(v, deleteidxs)
 end
-
-# Improved performance of `delaunayedges()`
-# see: https://github.com/JuliaGeometry/VoronoiDelaunay.jl/issues/47
-function delaunayedges_fast(t::DelaunayTessellation2D{T}) where T <: AbstractPoint2D
-    result = DelaunayEdge{T}[]
-    @inbounds for ix in 2:t._last_trig_index
-        tr = t._trigs[ix]
-        isexternal(tr) && continue
-
-        ix_na = tr._neighbour_a
-        if (ix_na > ix) | isexternal(t._trigs[ix_na])
-            push!(result, DelaunayEdge(getb(tr), getc(tr)))
-        end
-        ix_nb = tr._neighbour_b
-        if (ix_nb > ix) | isexternal(t._trigs[ix_nb])
-            push!(result, DelaunayEdge(geta(tr), getc(tr)))
-        end
-        ix_nc = tr._neighbour_c
-        if (ix_nc > ix) | isexternal(t._trigs[ix_nc])
-            push!(result, DelaunayEdge(geta(tr), getb(tr)))
-        end
-    end
-    return result
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 distance(p1::Complex, p2::Complex) = hypot(p2 - p1)
 distance((p1, p2)::Tuple{Complex, Complex}) = distance(p1, p2)
 function distance(p1::AbstractPoint2D, p2::AbstractPoint2D)
-    z1 = complex(p1._x, p1._y)
-    z2 = complex(p2._x, p2._y)
+    z1 = complex(p1.x, p1.y)
+    z2 = complex(p2.x, p2.y)
     return distance(z1, z2)
 end
 

--- a/test/DefaultFunction.jl
+++ b/test/DefaultFunction.jl
@@ -61,7 +61,7 @@ tmpr, tmpp = grpf(defaultfcn, origcoords, GRPFParams(8000, 1e-9, true))
 # Test with very low maxnodes
 maxnodes = 10
 params = GRPFParams(100, maxnodes, 3, maxnodes-1, 1e-9, false)
-@test_logs (:warn,"GRPFParams.maxnodes reached") grpf(defaultfcn, origcoords, PlotData(), params)
+@test_logs (:warn,"params.maxnodes reached") grpf(defaultfcn, origcoords, PlotData(), params)
 
 # Test with big origcoords
 xb = big(xb)  # real part begin

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -1,153 +1,258 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
-uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
+manifest_format = "2.0"
 
-[[Base64]]
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[ChainRulesCore]]
-deps = ["LinearAlgebra", "MuladdMacro", "SparseArrays"]
-git-tree-sha1 = "15081c431bb25848ad9b0d172a65794f3a3e197a"
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "7dd38532a1115a215de51775f9891f0f3e1bac6a"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.24"
+version = "1.12.1"
 
-[[ColorTypes]]
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
+
+[[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "4bffea7ed1a9f0f3d1a131bbcd4b925548d75288"
+git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.9"
+version = "0.11.0"
 
-[[Colors]]
-deps = ["ColorTypes", "FixedPointNumbers", "InteractiveUtils", "Reexport"]
-git-tree-sha1 = "008d6bc68dea6beb6303fdc37188cb557391ebf2"
+[[deps.Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
 uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
-version = "0.12.4"
+version = "0.12.8"
 
-[[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
+[[deps.Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.41.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.3.4+0"
 
-[[Dates]]
+[[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[Distributed]]
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
-[[FixedPointNumbers]]
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.FixedPointNumbers]]
 deps = ["Statistics"]
 git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
-[[GeometricalPredicates]]
-git-tree-sha1 = "04776c0dc233eafa617b1a52ca58db2338b08836"
+[[deps.GeometricalPredicates]]
+git-tree-sha1 = "527d55e28ff359029d8f72d77c0bdcaf28793079"
 uuid = "fd0ad045-b25c-564e-8f9c-8ef5c5f21267"
-version = "0.4.0"
+version = "0.4.1"
 
-[[InteractiveUtils]]
+[[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[JLLWrappers]]
-git-tree-sha1 = "c70593677bbf2c3ccab4f7500d0f4dacfff7b75c"
-uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.1.3"
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.2"
 
-[[LibGit2]]
-deps = ["Printf"]
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.4.1"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[Libdl]]
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LinearAlgebra]]
-deps = ["Libdl"]
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
-[[Logging]]
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.6"
+
+[[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
-[[Markdown]]
+[[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MuladdMacro]]
-git-tree-sha1 = "c6190f9a7fc5d9d5915ab29f2134421b12d24a68"
-uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.2"
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 
-[[OpenSpecFun_jll]]
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+4"
+version = "0.5.5+0"
 
-[[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
-[[Printf]]
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
+
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
-[[Random]]
-deps = ["Serialization"]
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[Reexport]]
-deps = ["Pkg"]
-git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "0.2.0"
+version = "1.2.2"
 
-[[SHA]]
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
-[[Serialization]]
+[[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[Sockets]]
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
-[[SparseArrays]]
+[[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
-[[SpecialFunctions]]
-deps = ["ChainRulesCore", "OpenSpecFun_jll"]
-git-tree-sha1 = "75394dbe2bd346beeed750fb02baa6445487b862"
+[[deps.SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "2735e252e72ee0367ebdb10b6148343fd15c2481"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.2.1"
+version = "1.8.3"
 
-[[Statistics]]
+[[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
-[[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[UUIDs]]
+[[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
-[[Unicode]]
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[VoronoiDelaunay]]
+[[deps.VoronoiDelaunay]]
 deps = ["Colors", "GeometricalPredicates", "Random"]
-git-tree-sha1 = "da5560a4c7c767476e85e2dbf4d8c8ca112e542b"
+git-tree-sha1 = "ed19f55808fb99951d36e8616a95fc9d94045466"
 uuid = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
-version = "0.4.0"
+version = "0.4.1"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,6 +5,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VoronoiDelaunay = "72f80fcb-8c52-57d9-aff0-40c1a3526986"
 
 [compat]
-SpecialFunctions = "0.10, 1"
-VoronoiDelaunay = "0.4"
-julia = "1.4"
+SpecialFunctions = "1"
+VoronoiDelaunay = "0.4.1"
+julia = "1.7"


### PR DESCRIPTION
- Remove custom fast `delaunayedges` implementation. Fixed by https://github.com/JuliaGeometry/VoronoiDelaunay.jl/pull/59
- Bump minimum Julia to `v1.7` and upgrades Manifest to version 2.0
- Immutable `GRPFParams` (closes #13)
- Some cleanup/simplification

Runtime is still dominated (>90%) by pushing new nodes into the VoronoiDelaunay.jl triangulation.